### PR TITLE
Add missing repository field to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "hyperfeed",
     "RSS"
   ],
+  "repository": "poga/feed-hyperify",
   "author": "Poga Po<poga.bahamut@gmail.com>",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
So the source shows up on https://www.npmjs.com/package/feed-hyperify